### PR TITLE
Fix usage of DeclareNameFormat (biblatex >= 3.3)

### DIFF
--- a/lncs.bbx
+++ b/lncs.bbx
@@ -121,15 +121,25 @@
 \renewcommand{\labelnamepunct}{\addcolon\space}
 
 \DeclareNameFormat{author}{%
-  \ifblank{#5}{}{#5\space}#1, #4%
+  \nameparts{#1}%
+  \usebibmacro{name:family-given}
+          {\namepartfamily}
+          {\namepartgiveni}
+          {\namepartprefix}
+          {\namepartsuffix}
   \ifthenelse{\value{listcount}<\value{liststop}}
     {\addcomma\space}%
     {}%
 }
 
 \DeclareNameFormat{editor}{%
-  \ifblank{#5}{}{#5\space}#1, #4%
-  \ifthenelse{\value{listcount}<\value{liststop}}
+  \nameparts{#1}%
+  \usebibmacro{name:family-given}
+          {\namepartfamily}
+          {\namepartgiveni}
+          {\namepartprefix}
+          {\namepartsuffix}
+    \ifthenelse{\value{listcount}<\value{liststop}}
     {\addcomma\space}%
     {\space\ifthenelse{\value{listcount}>1}
       {(\bibstring{editors})}


### PR DESCRIPTION
The syntax of `\DeclareNameFormat` changed at biblatex 3.3 (see https://github.com/plk/biblatex/issues/372).

This is a quick fix to let biblatex-lncs work again.

A better fix is to check for `\abx@version` (see https://github.com/plk/biblatex/issues/372#issuecomment-194506843), but I think, old versions will vanish and we should move forward. :innocent: 

Note: The call to `\nameparts` got obsolete with biblatex v3.4 (see https://github.com/plk/biblatex/blob/dev/doc/latex/biblatex/CHANGES). Thus, that call could be removed, too.
